### PR TITLE
Allow newer versions of packageurl, allow python 3.11

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,7 @@ classifiers = [
     'Topic :: Software Development',
     'Topic :: System :: Software Distribution',
     'License :: OSI Approved :: Apache Software License',
+    'Programming Language :: Python :: 3.6',
     'Programming Language :: Python :: 3.7',
     'Programming Language :: Python :: 3.8',
     'Programming Language :: Python :: 3.9',
@@ -57,7 +58,7 @@ keywords = [
 [tool.poetry.dependencies]
 python = "^3.6.2"
 importlib-metadata = { version = ">= 3.4", python = "< 3.8" }
-packageurl-python = ">=0.11, <2"
+packageurl-python = ">=0.9.0, <2"
 PyYAML = ">=5.4.1, <7.0.0"
 requests = "^2.20.0"
 tinydb = "^4.5.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,11 +40,11 @@ classifiers = [
     'Topic :: Software Development',
     'Topic :: System :: Software Distribution',
     'License :: OSI Approved :: Apache Software License',
-    'Programming Language :: Python :: 3.6',
     'Programming Language :: Python :: 3.7',
     'Programming Language :: Python :: 3.8',
     'Programming Language :: Python :: 3.9',
     'Programming Language :: Python :: 3.10',
+    'Programming Language :: Python :: 3.11',
     'Typing :: Typed'
 ]
 keywords = [
@@ -57,7 +57,7 @@ keywords = [
 [tool.poetry.dependencies]
 python = "^3.6.2"
 importlib-metadata = { version = ">= 3.4", python = "< 3.8" }
-packageurl-python = "^0.9.0"
+packageurl-python = ">=0.11, <2"
 PyYAML = ">=5.4.1, <7.0.0"
 requests = "^2.20.0"
 tinydb = "^4.5.0"

--- a/requirements.lowest.txt
+++ b/requirements.lowest.txt
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-packageurl-python == 0.11
+packageurl-python == 0.9.0
 importlib-metadata == 3.4.0 # ; python_version < '3.8'
 PyYAML == 5.4.1
 requests == 2.20.0

--- a/requirements.lowest.txt
+++ b/requirements.lowest.txt
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-packageurl-python == 0.9.0
+packageurl-python == 0.11
 importlib-metadata == 3.4.0 # ; python_version < '3.8'
 PyYAML == 5.4.1
 requests == 2.20.0

--- a/tox.ini
+++ b/tox.ini
@@ -19,7 +19,7 @@ minversion = 3.10
 envlist =
     flake8
     mypy-{locked,lowest}
-    py{311,310,39,38,37}-{locked,lowest}
+    py{311,310,39,38,37,36}-{locked,lowest}
 isolated_build = True
 skip_missing_interpreters = True
 usedevelop = False

--- a/tox.ini
+++ b/tox.ini
@@ -19,7 +19,7 @@ minversion = 3.10
 envlist =
     flake8
     mypy-{locked,lowest}
-    py{310,39,38,37,36}-{locked,lowest}
+    py{311,310,39,38,37}-{locked,lowest}
 isolated_build = True
 skip_missing_interpreters = True
 usedevelop = False


### PR DESCRIPTION
The packageurl API that is consumed by this project is unchanged since 0.9, so we should tolerate newer versions, which allows ossindex-lib to be used together with cyclonedx.

This library also works fine with python3.11, so support that in poetry and tox.