### PR TITLE
feat: add support for configurable OSS Index host URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,9 +47,11 @@ pip install ossindex-lib
 
 ## Usage
 
-First create an instance of `OssIndex`, optionally enabling local caching
+First create an instance of `OssIndex`, optionally enabling local caching and configuring a custom OSS Index host
 ```
 o = OssIndex()
+# or with a custom host
+o = OssIndex(host='https://custom.ossindex.example.com')
 ```
 
 Then supply a `List` of [PackageURL](https://github.com/package-url/packageurl-python) objects that you want to ask

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -57,3 +57,24 @@ enable authenticated calls to OSS Index:
 
    username: my-oss-index-username
    password: my-oss-index-password
+
+Configuring a Custom OSS Index Host
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+You can configure a custom OSS Index host URL in two ways:
+
+1. **Via constructor parameter** (takes precedence):
+
+.. code-block::
+
+  ossi = OssIndex(host='https://custom.ossindex.example.com')
+
+2. **Via configuration file** (``$HOME/.oss-index.config``):
+
+.. code-block::
+
+   username: my-oss-index-username
+   password: my-oss-index-password
+   host: https://custom.ossindex.example.com
+
+The constructor parameter takes precedence over the configuration file setting.

--- a/ossindex/ossindex.py
+++ b/ossindex/ossindex.py
@@ -60,7 +60,8 @@ class OssIndex:
     _oss_index_authentication: Optional[requests.auth.HTTPBasicAuth] = None
 
     def __init__(self, *, enable_cache: bool = True, cache_location: Optional[str] = None,
-                 username: Optional[str] = None, password: Optional[str] = None) -> None:
+                 username: Optional[str] = None, password: Optional[str] = None,
+                 host: Optional[str] = None) -> None:
         self._caching_enabled = enable_cache
         if self._caching_enabled:
             logger.info('OssIndex caching is ENABLED')
@@ -73,6 +74,11 @@ class OssIndex:
             logger.debug('Attempting to load credentials for OSS Index from configuration file')
             self._attempt_config_load()
 
+        # Host parameter takes precedence over config file
+        if host:
+            logger.debug(f'Using custom OSS Index host: {host}')
+            self._oss_index_host = host.rstrip('/')
+
     def has_ossindex_authentication(self) -> bool:
         return self._oss_index_authentication is not None
 
@@ -81,9 +87,13 @@ class OssIndex:
             config_filename: str = os.path.join(os.path.expanduser('~'), OssIndex.DEFAULT_CONFIG_FILE)
             with open(config_filename, 'r') as ossindex_confg_f:
                 ossindex_config = yaml.safe_load(ossindex_confg_f.read())
-                self._oss_index_authentication = requests.auth.HTTPBasicAuth(
-                    ossindex_config['username'], ossindex_config['password']
-                )
+                if 'username' in ossindex_config and 'password' in ossindex_config:
+                    self._oss_index_authentication = requests.auth.HTTPBasicAuth(
+                        ossindex_config['username'], ossindex_config['password']
+                    )
+                if 'host' in ossindex_config:
+                    logger.debug(f'Loading custom OSS Index host from config: {ossindex_config["host"]}')
+                    self._oss_index_host = ossindex_config['host'].rstrip('/')
         except FileNotFoundError:
             pass
 

--- a/tests/test_ossindex.py
+++ b/tests/test_ossindex.py
@@ -155,3 +155,28 @@ class TestOssIndex(TestCase):
             self.assertEqual(2, len(results2))
             for oic_ in results2:
                 self.assertIsInstance(oic_, OssIndexComponent)
+
+    @mock.patch('requests.post', side_effect=mock_oss_index_post)
+    def test_oss_index_with_custom_host(self, mock_post: Mock) -> None:
+        custom_host = 'https://custom.ossindex.example.com'
+        oss: OssIndex = OssIndex(enable_cache=False, host=custom_host)
+
+        # Verify the custom host is set
+        self.assertEqual(custom_host, oss._oss_index_host)
+
+        # Verify the API URL uses the custom host
+        api_url = oss._get_api_url('component-report')
+        self.assertTrue(api_url.startswith(custom_host))
+        self.assertEqual(f'{custom_host}/api/v3/component-report', api_url)
+
+    @mock.patch('requests.post', side_effect=mock_oss_index_post)
+    def test_oss_index_with_custom_host_trailing_slash(self, mock_post: Mock) -> None:
+        custom_host_with_slash = 'https://custom.ossindex.example.com/'
+        oss: OssIndex = OssIndex(enable_cache=False, host=custom_host_with_slash)
+
+        # Verify trailing slash is removed
+        self.assertEqual('https://custom.ossindex.example.com', oss._oss_index_host)
+
+        # Verify the API URL is correctly formed
+        api_url = oss._get_api_url('component-report')
+        self.assertEqual('https://custom.ossindex.example.com/api/v3/component-report', api_url)


### PR DESCRIPTION
## Summary

This PR adds the ability to configure a custom OSS Index host URL, enabling users to point to custom OSS Index instances for testing, enterprise deployments, or compliance requirements.

## Changes

### Code Changes
- **`ossindex/ossindex.py`**: Added `host` parameter to `OssIndex.__init__()`
  - Constructor parameter takes precedence over config file
  - Automatically strips trailing slashes from URLs
  - Added logging for custom host usage
- **`ossindex/ossindex.py`**: Updated `_attempt_config_load()` to read `host` from `.oss-index.config`
  - Made username/password optional in config (only load if present)

### Test Changes
- **`tests/test_ossindex.py`**: Added two new test methods:
  - `test_oss_index_with_custom_host`: Verifies custom host parameter works
  - `test_oss_index_with_custom_host_trailing_slash`: Verifies trailing slash handling

### Documentation Changes
- **`README.md`**: Updated usage example to show custom host parameter
- **`docs/usage.rst`**: Added "Configuring a Custom OSS Index Host" section

## Configuration Methods

Users can configure a custom OSS Index host in two ways:

1. **Via constructor parameter** (takes precedence):
```python
oss = OssIndex(host='https://custom.ossindex.example.com')
```

2. **Via configuration file** (`$HOME/.oss-index.config`):
```yaml
username: my-username
password: my-password
host: https://custom.ossindex.example.com
```

## Backward Compatibility

All changes are backward compatible. Existing code continues to work without modification, defaulting to `https://ossindex.sonatype.org`.

## Testing

- ✅ Syntax validation passed
- ✅ Two new tests added for custom host functionality
- ⚠️ Full test suite not run locally (requires environment setup)

## Use Cases

- Testing against staging/development OSS Index environments
- Enterprise deployments with custom OSS Index mirrors
- Compliance with network policies requiring specific endpoints
- Development and debugging workflows